### PR TITLE
FIX: the problem of pos_color and negative_color always being reversed.

### DIFF
--- a/fairml/graphing.py
+++ b/fairml/graphing.py
@@ -61,7 +61,7 @@ def plot_dependencies(dictionary_values,
 
     fig = plt.figure(figsize=fig_size)
 
-    bar_colors = assign_colors_to_bars(coefficient_values, reverse=True)
+    bar_colors = assign_colors_to_bars(coefficient_values, reverse=reverse_values)
     bar_colors = list(np.array(bar_colors)[index_sorted])
 
     plt.barh(pos, sorted_column_values, align='center', color=bar_colors)


### PR DESCRIPTION
Hi!
I found a problem where the color is always the opposite of the specified color.

I set pos_color="#3DE8F7"(Blue),negative_color="#ff4d4d"(red).
The color are always reversed, even if the argument `reverse_values` is True or False in prahing.py/plot_dependencies.
![image](https://user-images.githubusercontent.com/51149822/108492411-78d2eb80-72e8-11eb-80f9-325e5a20c1d5.png)

So I found the cause and fixed it! 

It would be great if you could reflect this.

